### PR TITLE
Feature: File explorer for download and workspace selection

### DIFF
--- a/utils/managers.py
+++ b/utils/managers.py
@@ -584,7 +584,7 @@ class FileManager:
             self.create_path(rasters_path)
         return tif_files_dict
 
-    def download_raster(self, rast_url):
+    def download_raster(self, rast_url, rast_directory):
         """
             Downloads a raster file into the systems memory from an URL.
 
@@ -595,7 +595,7 @@ class FileManager:
                 Download URL of the raster file.
         """
         file_name = rast_url.rsplit('/', 1)[1]
-        file_dir = os.path.join(self.rasters_dir, file_name)
+        file_dir = os.path.join(rast_directory, file_name)
 
         # wget.download(rast_url, file_dir)
         parameter_dictionary = {

--- a/utils/managers.py
+++ b/utils/managers.py
@@ -560,7 +560,7 @@ class FileManager:
         else:
             print('The path [{}] is already in the workspace'.format(path))
 
-    def list_rasters(self, rasters_path):
+    def list_rasters(self, rasters_folder):
         """
             Returns a list of raster files contained in a path of the system if
             the path exist, otherwise it will create the path.
@@ -572,16 +572,15 @@ class FileManager:
                 Path from where the raster files will be listed with respect to
                 the plugin absolute path.
         """
-        rasters_dir = os.path.join(self.plugin_dir,rasters_path)
         tif_files_dict = dict()
-        if os.path.exists(rasters_dir):
-            for dirpath, _, fnames in os.walk(rasters_dir):
+        if os.path.exists(rasters_folder):
+            for dirpath, _, fnames in os.walk(rasters_folder):
                 for file in fnames:
                     if file.endswith(".tif"):
                         tif_files_dict[file] = os.path.join(dirpath, file)
-            print('Found {} layers in the workspace [{}]'.format(len(tif_files_dict),rasters_path))
+            print('Found {} layers in the workspace [{}]'.format(len(tif_files_dict),rasters_folder))
         else:
-            self.create_path(rasters_path)
+            self.create_path(rasters_folder)
         return tif_files_dict
 
     def download_raster(self, rast_url, rast_directory):
@@ -705,6 +704,9 @@ class CanvasManager:
             return False
         return True
     
+    def set_rasters_dir(self, dir):
+        self.rasters_dir = dir
+
     def rm_rast(self, raster):
         raise NotImplementedError("Canvar Manager, Remove raster not implemented.")
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -5,6 +5,7 @@ from qgis.PyQt.QtGui import QColor
 
 from shapely.geometry import Polygon
 
+
 class CoordinatesSelectorTool(QgsMapTool):   
     """
         Class used to define a tool to select coordinates from the canvas of QGIS.

--- a/wap_plugin.py
+++ b/wap_plugin.py
@@ -647,7 +647,6 @@ class WAPlugin:
             self.dlg.RasterRefreshButton.clicked.connect(self.listRasterMemory)
 
             self.dlg.rasterFolderExplorer.fileChanged.connect(self.updateRasterFolder)
-            # self.dlg.indicatorRasterFolderExplorer.fileChanged.connect(self.layer_folder_dir)
 
             self.dlg.workspaceComboBox.currentIndexChanged.connect(self.workspaceChange)
             self.dlg.cubeComboBox.currentIndexChanged.connect(self.cubeChange)

--- a/wap_plugin.py
+++ b/wap_plugin.py
@@ -310,7 +310,8 @@ class WAPlugin:
             Calls the list rasters function of the file manager and updates 
             the UI in response to the result.
         """
-        self.tif_files = self.file_manag.list_rasters(self.rasters_path)
+        rasterFolder = self.dlg.rasterFolderExplorer.filePath()
+        self.tif_files = self.file_manag.list_rasters(rasterFolder)
         self.dlg.rasterMemoryComboBox.clear()
         self.dlg.rasterMemoryComboBox.addItems(self.tif_files.keys())
 
@@ -496,12 +497,18 @@ class WAPlugin:
 
         rast_url = self.api_manag.query_crop_raster(params)
 
-        rast_directory = self.dlg.downloadFileExplorer.filePath()
+        rast_directory = self.dlg.downloadFolderExplorer.filePath()
         self.file_manag.download_raster(rast_url, rast_directory)
         
         self.dlg.progressBar.setValue(100)
         self.dlg.progressLabel.setText ('Raster Download Complete')
         
+        self.listRasterMemory()
+
+    def updateRasterFolder(self):
+        rasterFolder = self.dlg.rasterFolderExplorer.filePath()
+        self.canv_manag.set_rasters_dir(rasterFolder)
+
         self.listRasterMemory()
 
     def loadRaster(self):
@@ -632,10 +639,15 @@ class WAPlugin:
             self.dlg.saveTokenButton.clicked.connect(self.saveToken)
             self.dlg.loadTokenButton.clicked.connect(self.loadToken)
 
-            self.dlg.downloadFileExplorer.setFilePath(self.layer_folder_dir)
+            self.dlg.rasterFolderExplorer.setFilePath(self.layer_folder_dir)
+            self.dlg.indicatorRasterFolderExplorer.setFilePath(self.layer_folder_dir)
+            self.dlg.downloadFolderExplorer.setFilePath(self.layer_folder_dir)
             self.dlg.downloadButton.clicked.connect(self.downloadCroppedRaster)
             self.dlg.loadRasterButton.clicked.connect(self.loadRaster)
             self.dlg.RasterRefreshButton.clicked.connect(self.listRasterMemory)
+
+            self.dlg.rasterFolderExplorer.fileChanged.connect(self.updateRasterFolder)
+            # self.dlg.indicatorRasterFolderExplorer.fileChanged.connect(self.layer_folder_dir)
 
             self.dlg.workspaceComboBox.currentIndexChanged.connect(self.workspaceChange)
             self.dlg.cubeComboBox.currentIndexChanged.connect(self.cubeChange)

--- a/wap_plugin.py
+++ b/wap_plugin.py
@@ -496,7 +496,8 @@ class WAPlugin:
 
         rast_url = self.api_manag.query_crop_raster(params)
 
-        self.file_manag.download_raster(rast_url)
+        rast_directory = self.dlg.downloadFileExplorer.filePath()
+        self.file_manag.download_raster(rast_url, rast_directory)
         
         self.dlg.progressBar.setValue(100)
         self.dlg.progressLabel.setText ('Raster Download Complete')
@@ -594,10 +595,6 @@ class WAPlugin:
             self.canv_manag.add_rast(output_name)
         else:
             raise NotImplementedError("Indicator: '{}' not implemented yet.".format(self.indicator))
-        
-        # self.canv_manag.add_rast(tbp_name)
-        # self.canv_manag.add_rast(aeti_name)
-        # self.canv_manag.add_rast(output_name)
     
     def getCrs(self):
         """
@@ -635,6 +632,7 @@ class WAPlugin:
             self.dlg.saveTokenButton.clicked.connect(self.saveToken)
             self.dlg.loadTokenButton.clicked.connect(self.loadToken)
 
+            self.dlg.downloadFileExplorer.setFilePath(self.layer_folder_dir)
             self.dlg.downloadButton.clicked.connect(self.downloadCroppedRaster)
             self.dlg.loadRasterButton.clicked.connect(self.loadRaster)
             self.dlg.RasterRefreshButton.clicked.connect(self.listRasterMemory)

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -26,7 +26,7 @@
     <item>
      <widget class="QTabWidget" name="tabMaganer">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="signinTab">
        <attribute name="title">
@@ -499,27 +499,6 @@
             <string>WaPOR Data</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,1">
-              <item>
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>Rasters Folder</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QgsFileWidget" name="indicatorRasterFolderExplorer">
-                <property name="filter">
-                 <string/>
-                </property>
-                <property name="storageMode">
-                 <enum>QgsFileWidget::GetDirectory</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -294,7 +294,11 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsFileWidget" name="fileExplorer"/>
+                <widget class="QgsFileWidget" name="downloadFileExplorer">
+                 <property name="storageMode">
+                  <enum>QgsFileWidget::GetDirectory</enum>
+                 </property>
+                </widget>
                </item>
                <item>
                 <widget class="QLineEdit" name="outputRasterName"/>

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -282,13 +282,19 @@
               </layout>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,3,2,2">
+               <property name="sizeConstraint">
+                <enum>QLayout::SetDefaultConstraint</enum>
+               </property>
                <item>
                 <widget class="QLabel" name="label">
                  <property name="text">
-                  <string>Output file name:                               </string>
+                  <string>Output file:</string>
                  </property>
                 </widget>
+               </item>
+               <item>
+                <widget class="QgsFileWidget" name="fileExplorer"/>
                </item>
                <item>
                 <widget class="QLineEdit" name="outputRasterName"/>
@@ -617,6 +623,13 @@
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -294,7 +294,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsFileWidget" name="downloadFileExplorer">
+                <widget class="QgsFileWidget" name="downloadFolderExplorer">
                  <property name="storageMode">
                   <enum>QgsFileWidget::GetDirectory</enum>
                  </property>
@@ -348,27 +348,33 @@
               <height>61</height>
              </rect>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_14">
+            <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="4,4,2,1">
+             <item>
+              <widget class="QgsFileWidget" name="rasterFolderExplorer">
+               <property name="filter">
+                <string/>
+               </property>
+               <property name="storageMode">
+                <enum>QgsFileWidget::GetDirectory</enum>
+               </property>
+              </widget>
+             </item>
              <item>
               <widget class="QComboBox" name="rasterMemoryComboBox"/>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_13">
-               <item>
-                <widget class="QPushButton" name="loadRasterButton">
-                 <property name="text">
-                  <string>Load in canvas</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="RasterRefreshButton">
-                 <property name="text">
-                  <string>Refresh</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QPushButton" name="loadRasterButton">
+               <property name="text">
+                <string>Load in canvas</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="RasterRefreshButton">
+               <property name="text">
+                <string>Refresh</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>
@@ -493,6 +499,27 @@
             <string>WaPOR Data</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,1">
+              <item>
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>Rasters Folder</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QgsFileWidget" name="indicatorRasterFolderExplorer">
+                <property name="filter">
+                 <string/>
+                </property>
+                <property name="storageMode">
+                 <enum>QgsFileWidget::GetDirectory</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>


### PR DESCRIPTION
## What?
A file explorer was implemented for selecting a folder into which the downloaded rasters will be saved, in addition to a second file explorer to select the workspace from where the rasters will be uploaded and the indicators will be calculated.

## Why?
It was requested by a user to provide flexibility in the file management when downloading new rasters.

## How?
The file explorers receive a default path inside the plugin, but can change with the interactions of the user:
- The download file explorer changes the path of saving the rasters.
- The workspace file explorer changes the path for listing raster in memory to be used in the load and in the indicator calculator.

## Testing?
It was pitched to the CEO and Marketing leader with their approval.

