### PR TITLE
Feature: Mirroring file explorer in the indicator calculator

### DIFF
--- a/wap_plugin.py
+++ b/wap_plugin.py
@@ -314,6 +314,15 @@ class WAPlugin:
         self.tif_files = self.file_manag.list_rasters(rasterFolder)
         self.dlg.rasterMemoryComboBox.clear()
         self.dlg.rasterMemoryComboBox.addItems(self.tif_files.keys())
+    
+    def listRasterCalcMemory(self):
+        """
+            Calls the list rasters function of the file manager to get the rasters
+            for the indicator calculator.
+        """
+        rasterFolderCalc = self.dlg.rasterFolderCalcExplorer.filePath()
+        self.tif_calc_files = self.file_manag.list_rasters(rasterFolderCalc)
+
 
     def workspaceChange(self):
         """
@@ -382,7 +391,7 @@ class WAPlugin:
                             for factor in INDICATORS_INFO[self.indicator_key]['factors']])
         
         """ Raster Files Filtered Update """
-        self.listRasterMemory()
+        self.listRasterCalcMemory()
 
         """ Parameters Update """
         if INDICATORS_INFO[self.indicator_key]['params']['PARAM_1'] == '':
@@ -390,7 +399,7 @@ class WAPlugin:
             self.dlg.Param1ComboBox.setEnabled(False)
         else:
             self.dlg.Param1Label.setText(INDICATORS_INFO[self.indicator_key]['params']['PARAM_1']['label'])
-            filteredRasterFiles = self.file_manag.filterRasterFiles(self.tif_files, INDICATORS_INFO[self.indicator_key]['params']['PARAM_1']['type'])
+            filteredRasterFiles = self.file_manag.filterRasterFiles(self.tif_calc_files, INDICATORS_INFO[self.indicator_key]['params']['PARAM_1']['type'])
             self.dlg.Param1ComboBox.clear()
             self.dlg.Param1ComboBox.addItems(filteredRasterFiles.keys())
             self.dlg.Param1ComboBox.setEnabled(True)
@@ -400,7 +409,7 @@ class WAPlugin:
             self.dlg.Param2ComboBox.setEnabled(False)
         else:
             self.dlg.Param2Label.setText(INDICATORS_INFO[self.indicator_key]['params']['PARAM_2']['label'])
-            filteredRasterFiles = self.file_manag.filterRasterFiles(self.tif_files, INDICATORS_INFO[self.indicator_key]['params']['PARAM_2']['type'])
+            filteredRasterFiles = self.file_manag.filterRasterFiles(self.tif_calc_files, INDICATORS_INFO[self.indicator_key]['params']['PARAM_2']['type'])
             self.dlg.Param2ComboBox.clear()
             self.dlg.Param2ComboBox.addItems(filteredRasterFiles.keys())
             self.dlg.Param2ComboBox.setEnabled(True)
@@ -521,6 +530,12 @@ class WAPlugin:
         self.canv_manag.set_rasters_dir(rasterFolder)
 
         self.listRasterMemory()
+
+        self.dlg.rasterFolderCalcExplorer.setFilePath(rasterFolder)
+
+
+    def updateRasterFolderCalc(self):
+        self.indicatorChange()
 
     def loadRaster(self):
         """
@@ -651,12 +666,14 @@ class WAPlugin:
             self.dlg.loadTokenButton.clicked.connect(self.loadToken)
 
             self.dlg.rasterFolderExplorer.setFilePath(self.layer_folder_dir)
+            self.dlg.rasterFolderCalcExplorer.setFilePath(self.layer_folder_dir)
             self.dlg.downloadFolderExplorer.setFilePath(self.layer_folder_dir)
             self.dlg.downloadButton.clicked.connect(self.downloadCroppedRaster)
             self.dlg.loadRasterButton.clicked.connect(self.loadRaster)
             self.dlg.RasterRefreshButton.clicked.connect(self.listRasterMemory)
 
             self.dlg.rasterFolderExplorer.fileChanged.connect(self.updateRasterFolder)
+            self.dlg.rasterFolderCalcExplorer.fileChanged.connect(self.updateRasterFolderCalc)
 
             self.dlg.workspaceComboBox.currentIndexChanged.connect(self.workspaceChange)
             self.dlg.cubeComboBox.currentIndexChanged.connect(self.cubeChange)

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>556</width>
-    <height>657</height>
+    <width>553</width>
+    <height>663</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,7 +26,7 @@
     <item>
      <widget class="QTabWidget" name="tabMaganer">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="signinTab">
        <attribute name="title">
@@ -172,7 +172,7 @@
          <item>
           <widget class="QGroupBox" name="rasterSelectionBox">
            <property name="title">
-            <string>Choose Raster</string>
+            <string>Raster Download</string>
            </property>
            <widget class="QWidget" name="layoutWidget_3">
             <property name="geometry">
@@ -301,7 +301,7 @@
                 <enum>QLayout::SetDefaultConstraint</enum>
                </property>
                <item>
-                <widget class="QLabel" name="label">
+                <widget class="QLabel" name="outputFileCatalogLabel">
                  <property name="text">
                   <string>Output file:</string>
                  </property>
@@ -351,7 +351,7 @@
          <item>
           <widget class="QGroupBox" name="rasterLoadBox">
            <property name="title">
-            <string>Available Rasters</string>
+            <string>Raster Load</string>
            </property>
            <widget class="QWidget" name="layoutWidget_5">
             <property name="geometry">
@@ -397,7 +397,7 @@
          <item>
           <widget class="QGroupBox" name="coordinateSelectionBox">
            <property name="title">
-            <string>Co-ordinate Selection</string>
+            <string>Coordinate Selection</string>
            </property>
            <widget class="QWidget" name="layoutWidget_4">
             <property name="geometry">
@@ -483,7 +483,7 @@
           <height>511</height>
          </rect>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <layout class="QVBoxLayout" name="verticalLayout_2" stretch="4,4,3">
          <item>
           <widget class="QGroupBox" name="indicatorBox">
            <property name="title">
@@ -516,6 +516,20 @@
             <string>WaPOR Data</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="2,4">
+              <item>
+               <widget class="QLabel" name="rasterFolderCalculatorLabel">
+                <property name="text">
+                 <string>Rasters Folder</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QgsFileWidget" name="rasterFolderCalcExplorer"/>
+              </item>
+             </layout>
+            </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>

--- a/wap_plugin_dialog_base.ui
+++ b/wap_plugin_dialog_base.ui
@@ -526,7 +526,11 @@
                </widget>
               </item>
               <item>
-               <widget class="QgsFileWidget" name="rasterFolderCalcExplorer"/>
+               <widget class="QgsFileWidget" name="rasterFolderCalcExplorer">
+                <property name="storageMode">
+                 <enum>QgsFileWidget::GetDirectory</enum>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>


### PR DESCRIPTION
## What?
A file explorer was implemented for selecting a folder from which rasters will be loaded to be used in an indicator computation, initially it will mirror the value of the file explorer in the raster loading.

## Why?
Discussed with @akshaydr to provide flexibility to the user when interacting with the indicators.

## How?
The file explorers its initialized with the same default path of the raster loading but can change with the interactions of the user when computing indicators.

## Testing?
Pending from @akshaydr 